### PR TITLE
V3.7

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,32 @@
 # QuickRoute ChangeLog
 
+## v3.6 to v3.7
+### New Methods
+- RouteInterface::matchAny(array $methods, array $paths, $handler): RouteInterface - Generate multiple routes using multiple method and path but single handle
+- DispatchResult::route(string $routeName): ?array - This is to find route by its name
+- DispatchResult::uri(string $routeName): ?string - Generate route uri using route's name
+
+```php
+use QuickRoute\Route;
+
+Route::matchAny(
+    ['get', 'post'], 
+    ['/customer/login', '/admin/login'],
+    'MainController@index'
+);
+
+//Which is equivalent to:
+Route::get('/customer/login', 'MainController@index');
+Route::post('/customer/login', 'MainController@index');
+Route::get('/admin/login', 'MainController@index');
+Route::post('/admin/login', 'MainController@index');
+```
+
+
 ## v3.5 to v3.6
 ### New Methods
 - RouteInterface::where(string|array $param, ?string $regExp = null): RouteInterface
+- RouteInterface::matchAny(array $methods, array $paths, $handler): RouteInterface
 
 ```php
 use QuickRoute\Route;

--- a/README.md
+++ b/README.md
@@ -286,6 +286,19 @@ $dispatchResult = Dispatcher::create($collector)
 var_export($dispatchResult);
 ```
 
+#### Finding route & generating route uri
+
+```php
+use QuickRoute\Route;
+use QuickRoute\Router\Dispatcher;
+
+Route::get('/users', 'Controller@method')->name('users.index');
+
+$result = Dispatcher::collectRoutes()->dispatch('get', '/');
+echo $result->uri('users.index');  // => /users
+$result->route('users.index'); // => Array of route data
+```
+
 #### Note
 - You must be careful when using **Collector::collect()** and **Collector::collectFile()** together, 
 as collectFile method will clear previously collected routes before it starts collecting.<br/>

--- a/README.md
+++ b/README.md
@@ -161,6 +161,24 @@ $dispatchResult2 = Dispatcher::create($collector)
     ->dispatch('get', '/admin/login');
 ```
 
+#### Route::matchAny()
+
+```php
+use QuickRoute\Route;
+
+Route::matchAny(
+    ['get', 'post'], 
+    ['/customer/login', '/admin/login'],
+    'MainController@index'
+);
+
+//Which is equivalent to:
+Route::get('/customer/login', 'MainController@index');
+Route::post('/customer/login', 'MainController@index');
+Route::get('/admin/login', 'MainController@index');
+Route::post('/admin/login', 'MainController@index');
+```
+
 #### Route::resource()
 
 ```php

--- a/src/Route.php
+++ b/src/Route.php
@@ -20,8 +20,9 @@ use QuickRoute\Router\TheRoute;
  * @method static TheRoute patch(string $uri, callable|mixed $handler) Register this route as PATCH
  * @method static TheRoute delete(string $uri, callable|mixed $handler) Register this route as DELETE
  * @method static TheRoute head(string $uri, callable|mixed $handler) Register route to multiple http verbs
- * @method static TheRoute match(array|string $methods, string $uri, callable|mixed $handler) Register this route as HEAD
+ * @method static TheRoute match(array|string $methods, string $uri, callable|mixed $handler) Register single handle to multiple methods
  * @method static TheRoute any(array|string $paths, string $method, callable|mixed $handler) Register multiple paths to single handler
+ * @method static TheRoute matchAny(array|string $methods, array|string $paths, callable|mixed $handler) Register multiple methods and paths to single handle
  * @method static TheRoute resource(string $route, string $controller, string $idParameterName = 'id', bool $integerId = true) A single to handle variety of actions on the resource.
  * @method static TheRoute addField(string $name, callable|mixed $handler) Add field of data route collection
  */

--- a/src/RouteInterface.php
+++ b/src/RouteInterface.php
@@ -111,22 +111,30 @@ interface RouteInterface
 
     /**
      * Register route to multiple http verbs
-     * @param array|string $methods
+     * @param array $methods
      * @param string $uri
      * @param callable|mixed $handler
      * @return RouteInterface
      */
-    public function match($methods, string $uri, $handler): RouteInterface;
+    public function match(array $methods, string $uri, $handler): RouteInterface;
 
     /**
      * Register multiple paths to single handler
      *
-     * @param string|array $paths
+     * @param array $paths
      * @param string $method
      * @param callable|mixed $handler
      * @return RouteInterface
      */
-    public function any($paths, string $method, $handler): RouteInterface;
+    public function any(array $paths, string $method, $handler): RouteInterface;
+
+    /**
+     * @param array $methods
+     * @param array $paths
+     * @param callable|mixed $handler
+     * @return RouteInterface
+     */
+    public function matchAny(array $methods, array $paths, $handler): RouteInterface;
 
     /**
      * This single route declaration creates multiple routes to handle a variety of actions on the resource.

--- a/src/Router/Dispatcher.php
+++ b/src/Router/Dispatcher.php
@@ -86,7 +86,7 @@ class Dispatcher
         $urlData = $this->createDispatcher()
             ->dispatch(strtoupper($method), $path);
 
-        return new DispatchResult($urlData);
+        return new DispatchResult($urlData, $this->collector->getCollectedRoutes());
     }
 
     /**

--- a/src/Router/TheRoute.php
+++ b/src/Router/TheRoute.php
@@ -66,39 +66,48 @@ class TheRoute implements RouteInterface, JsonSerializable
     /**
      * @inheritDoc
      */
-    public function match($methods, string $uri, $handler): RouteInterface
+    public function match(array $methods, string $uri, $handler): RouteInterface
     {
-        if (is_array($methods)) {
-            foreach ($methods as $method) {
-                $method = strtolower($method);
-                $route = new TheRoute($this);
-                Route::push($route);
-                $route->$method($uri, $handler);
-            }
-
-            return $this;
+        foreach ($methods as $method) {
+            $method = strtolower($method);
+            $route = new TheRoute($this);
+            Route::push($route);
+            $route->$method($uri, $handler);
         }
 
-        return $this->addRoute($methods, $uri, $handler);
+        return $this;
     }
 
     /**
      * @inheritDoc
      */
-    public function any($paths, string $method, $handler): RouteInterface
+    public function any(array $paths, string $method, $handler): RouteInterface
     {
-        if (is_array($paths)) {
-            foreach ($paths as $path) {
+        foreach ($paths as $path) {
+            $method = strtolower($method);
+            $route = new TheRoute($this);
+            Route::push($route);
+            $route->$method($path, $handler);
+        }
+
+        return $this;
+    }
+
+    /**
+     * @inheritDoc
+     */
+    public function matchAny(array $methods, array $paths, $handler): RouteInterface
+    {
+        foreach ($methods as $method) {
+            foreach ($paths as $path){
                 $method = strtolower($method);
                 $route = new TheRoute($this);
                 Route::push($route);
                 $route->$method($path, $handler);
             }
-
-            return $this;
         }
 
-        return $this->addRoute($method, $paths, $handler);
+        return $this;
     }
 
     /**

--- a/test.php
+++ b/test.php
@@ -1,0 +1,13 @@
+<?php
+
+use QuickRoute\Route;
+use QuickRoute\Router\Dispatcher;
+
+require 'vendor/autoload.php';
+
+Route::prefix('school')->name('school')
+    ->group(function (){
+        Route::matchAny(['get', 'post'], ['/customer/login', '/admin/login'],'MainController@index')->name('login');
+    });
+
+dd(\QuickRoute\Router\Collector::create()->collect()->getCollectedRoutes());

--- a/tests/DispatcherTest.php
+++ b/tests/DispatcherTest.php
@@ -100,7 +100,6 @@ class DispatcherTest extends TestCase
         Route::get('users/profile', 'Controller@index');
         $result = Dispatcher::collectRoutes()
             ->dispatch('get', 'users/profile');
-        //dd($result->isFound());
 
         $result1 = Dispatcher::collectRoutesFile(__DIR__ . '/routes-1.php')
             ->dispatch('post', '/user/save');
@@ -108,4 +107,27 @@ class DispatcherTest extends TestCase
         self::assertSame('/users/profile', $result->getRoute()->getPrefix());
         self::assertSame('/user/save', $result1->getRoute()->getPrefix());
     }
+
+    public function testHelpers(): void
+    {
+        Route::restart();
+        Route::get('/', 'Controller@method')->name('home');
+        Route::get('/users/{id}/{name}', 'HelloController')
+            ->whereAlpha('id')
+            ->name('user.info');
+
+        $result = Dispatcher::collectRoutes()->dispatch('get', '/');
+        $uri = $result->uri('user.info', [
+            'id' => 1,
+            'name' => 'ahmard'
+        ]);
+
+        $route = $result->route('home');
+
+        self::assertTrue($result->isFound());
+        self::assertIsArray($route);
+        self::assertSame('Controller@method', $route['handler'] ?? null);
+        self::assertSame('/users/1/ahmard', $uri);
+    }
+
 }

--- a/tests/RouteRegisterTest.php
+++ b/tests/RouteRegisterTest.php
@@ -277,6 +277,22 @@ class RouteRegisterTest extends TestCase
         self::assertSame('DELETE', $routes[7]['method']);
     }
 
+    public function testMatchAny(): void
+    {
+        Route::restart();
+        Route::matchAny(['get', 'post'], ['/customer/login', '/admin/login'],'MainController@index');
+        $routes = Collector::create()->collect()->getCollectedRoutes();
+
+        self::assertSame('GET', $routes[0]['method']);
+        self::assertSame('/customer/login', $routes[0]['prefix']);
+        self::assertSame('GET', $routes[1]['method']);
+        self::assertSame('/admin/login', $routes[1]['prefix']);
+        self::assertSame('POST', $routes[2]['method']);
+        self::assertSame('/customer/login', $routes[2]['prefix']);
+        self::assertSame('POST', $routes[3]['method']);
+        self::assertSame('/admin/login', $routes[3]['prefix']);
+    }
+
     protected function setUp(): void
     {
         Route::restart();


### PR DESCRIPTION
- RouteInterface::matchAny(array $methods, array $paths, $handler): RouteInterface - Generate multiple routes using multiple method and path but single handle
- DispatchResult::route(string $routeName): ?array - This is to find route by its name
- DispatchResult::uri(string $routeName): ?string - Generate route uri using route's name
