### PR TITLE
RouteInterface::where...() methods parameter rename

### DIFF
--- a/src/RouteInterface.php
+++ b/src/RouteInterface.php
@@ -164,26 +164,26 @@ interface RouteInterface
     /**
      * Indicates that the given route parameters must be number.
      *
-     * @param string $parameterName
+     * @param string $param
      * @return RouteInterface
      */
-    public function whereNumber(string $parameterName): RouteInterface;
+    public function whereNumber(string $param): RouteInterface;
 
     /**
      * Indicates that the given route parameters must be alphabetic.
      *
-     * @param string $parameterName
+     * @param string $param
      * @return RouteInterface
      */
-    public function whereAlpha(string $parameterName): RouteInterface;
+    public function whereAlpha(string $param): RouteInterface;
 
     /**
      * Indicates that the given route parameters must be alphanumeric.
      *
-     * @param string $parameterName
+     * @param string $param
      * @return RouteInterface
      */
-    public function whereAlphaNumeric(string $parameterName): RouteInterface;
+    public function whereAlphaNumeric(string $param): RouteInterface;
 
     /**
      * Retrieve registered routes

--- a/src/Router/TheRoute.php
+++ b/src/Router/TheRoute.php
@@ -303,27 +303,27 @@ class TheRoute implements RouteInterface, JsonSerializable
     /**
      * @inheritDoc
      */
-    public function whereNumber(string $parameterName): RouteInterface
+    public function whereNumber(string $param): RouteInterface
     {
-        array_push($this->parameterTypes['number'], $parameterName);
+        array_push($this->parameterTypes['number'], $param);
         return $this;
     }
 
     /**
      * @inheritDoc
      */
-    public function whereAlpha(string $parameterName): RouteInterface
+    public function whereAlpha(string $param): RouteInterface
     {
-        array_push($this->parameterTypes['alpha'], $parameterName);
+        array_push($this->parameterTypes['alpha'], $param);
         return $this;
     }
 
     /**
      * @inheritDoc
      */
-    public function whereAlphaNumeric(string $parameterName): RouteInterface
+    public function whereAlphaNumeric(string $param): RouteInterface
     {
-        array_push($this->parameterTypes['alphanumeric'], $parameterName);
+        array_push($this->parameterTypes['alphanumeric'], $param);
         return $this;
     }
 


### PR DESCRIPTION
RouteInterface::whereNumber(), RouteInterface::whereAlpha(), RouteInterface::whereAlphaNumeric() parameter rename from "parameterName" to "param".
This change is made with the knowledge of how it will impact code written PHP >= 8.0.
This change is made to use named param easier, as "param" is more convenient to use than "parameterName"